### PR TITLE
feat(install): include the system toml configuration file in the package

### DIFF
--- a/packages/openrc/nfpm.yaml
+++ b/packages/openrc/nfpm.yaml
@@ -29,6 +29,13 @@ contents:
     dst: /usr/bin/
     file_info:
       mode: 0755
+
+  - src: ./services/system.toml
+    dst: /etc/tedge/system.toml
+    type: config
+    file_info:
+      mode: 0644
+
 scripts:
   postinstall: ./packages/_scripts/postinstall.sh
   preremove: ./packages/_scripts/preremove.sh

--- a/packages/runit/nfpm.yaml
+++ b/packages/runit/nfpm.yaml
@@ -22,6 +22,13 @@ contents:
     dst: /usr/bin/
     file_info:
       mode: 0755
+
+  - src: ./services/system.toml
+    dst: /etc/tedge/system.toml
+    type: config
+    file_info:
+      mode: 0644
+
 scripts:
   postinstall: ./packages/_scripts/postinstall.sh
   preremove: ./packages/_scripts/preremove.sh

--- a/packages/s6-overlay/nfpm.yaml
+++ b/packages/s6-overlay/nfpm.yaml
@@ -22,6 +22,13 @@ contents:
     dst: /usr/bin/
     file_info:
       mode: 0755
+
+  - src: ./services/system.toml
+    dst: /etc/tedge/system.toml
+    type: config
+    file_info:
+      mode: 0644
+
 scripts:
   postinstall: ./packages/_scripts/postinstall.sh
   preremove: ./packages/_scripts/preremove.sh

--- a/packages/sysvinit/nfpm.yaml
+++ b/packages/sysvinit/nfpm.yaml
@@ -24,6 +24,13 @@ contents:
     dst: /usr/bin/
     file_info:
       mode: 0755
+
+  - src: ./services/system.toml
+    dst: /etc/tedge/system.toml
+    type: config
+    file_info:
+      mode: 0644
+
 scripts:
   postinstall: ./packages/_scripts/postinstall.sh
   preremove: ./packages/_scripts/preremove.sh


### PR DESCRIPTION
The `/etc/tedge/system.toml` is included in the package which utilizes the service manager agnostic script, `tedgectl` to start/stop/enable/disable services.

The user is still free to edit the system.toml, and it shouldn't be overwritten on updates (as per the package manager functionality).