### PR TITLE
chore(tedgectl): rename display name to use lowercase only

### DIFF
--- a/services/system.toml
+++ b/services/system.toml
@@ -1,5 +1,5 @@
 [init]
-name = "TedgeCtl"
+name = "tedgectl"
 is_available = ["/usr/bin/tedgectl", "is_available"]
 restart = ["/usr/bin/tedgectl", "restart", "{}"]
 stop =  ["/usr/bin/tedgectl", "stop", "{}"]


### PR DESCRIPTION
Use lower case characters only in the `system.toml` configuration for service control using `tedgectl`.