### PR TITLE
fix(sysvinit): don't fail if removal works so it does not block re-enabling a service

### DIFF
--- a/services/tedgectl
+++ b/services/tedgectl
@@ -105,7 +105,7 @@ manage_sysvinit() {
             # Not all sysvinit systems support the enable/disable command
             update-rc.d "$name" disable 2>/dev/null ||:
 
-            update-rc.d "$name" remove
+            update-rc.d -f "$name" remove 2>/dev/null ||:
             ;;
         is_active|status)
             if command -V service >/dev/null 2>&1; then


### PR DESCRIPTION
Sometimes `tedgectl disable <service>` would fail using sysvinit on older versions.