### PR TITLE
feat(tedgectl): add support for reading settings from /etc/tedgectl/env

### DIFF
--- a/packages/openrc/nfpm.yaml
+++ b/packages/openrc/nfpm.yaml
@@ -30,6 +30,12 @@ contents:
     file_info:
       mode: 0755
 
+  - src: ./services/tedgectl_env
+    dst: /etc/tedgectl/env
+    type: config
+    file_info:
+      mode: 0644
+
   - src: ./services/system.toml
     dst: /etc/tedge/system.toml
     type: config

--- a/packages/runit/nfpm.yaml
+++ b/packages/runit/nfpm.yaml
@@ -23,6 +23,12 @@ contents:
     file_info:
       mode: 0755
 
+  - src: ./services/tedgectl_env
+    dst: /etc/tedgectl/env
+    type: config
+    file_info:
+      mode: 0644
+
   - src: ./services/system.toml
     dst: /etc/tedge/system.toml
     type: config

--- a/packages/s6-overlay/nfpm.yaml
+++ b/packages/s6-overlay/nfpm.yaml
@@ -23,6 +23,12 @@ contents:
     file_info:
       mode: 0755
 
+  - src: ./services/tedgectl_env
+    dst: /etc/tedgectl/env
+    type: config
+    file_info:
+      mode: 0644
+
   - src: ./services/system.toml
     dst: /etc/tedge/system.toml
     type: config

--- a/packages/supervisord/nfpm.yaml
+++ b/packages/supervisord/nfpm.yaml
@@ -25,6 +25,12 @@ contents:
     file_info:
       mode: 0755
 
+  - src: ./services/tedgectl_env
+    dst: /etc/tedgectl/env
+    type: config
+    file_info:
+      mode: 0644
+
   - src: ./services/system.toml
     dst: /etc/tedge/system.toml
     type: config

--- a/packages/sysvinit-yocto/nfpm.yaml
+++ b/packages/sysvinit-yocto/nfpm.yaml
@@ -25,6 +25,12 @@ contents:
     file_info:
       mode: 0755
 
+  - src: ./services/tedgectl_env
+    dst: /etc/tedgectl/env
+    type: config
+    file_info:
+      mode: 0644
+
   - src: ./services/system.toml
     dst: /etc/tedge/system.toml
     type: config

--- a/packages/sysvinit/nfpm.yaml
+++ b/packages/sysvinit/nfpm.yaml
@@ -25,6 +25,12 @@ contents:
     file_info:
       mode: 0755
 
+  - src: ./services/tedgectl_env
+    dst: /etc/tedgectl/env
+    type: config
+    file_info:
+      mode: 0644
+
   - src: ./services/system.toml
     dst: /etc/tedge/system.toml
     type: config

--- a/services/tedgectl
+++ b/services/tedgectl
@@ -1,6 +1,14 @@
 #!/bin/sh
 set -e
 
+# Support loading settings from file
+# this allows users to control which service manager is used by default
+# to disable auto detection.
+if [ -f /etc/tedgectl/env ]; then
+    # shellcheck disable=SC1091
+    . /etc/tedgectl/env
+fi
+
 #
 # Detect service manager
 #

--- a/services/tedgectl_env
+++ b/services/tedgectl_env
@@ -1,0 +1,4 @@
+# You can manually control which service manager is used
+# by uncommenting the line below and adding one of the values:
+#   systemd,openrc,runit,systemd,sysvinit,s6_overlay,supervisord
+#SERVICE_MANAGER=


### PR DESCRIPTION
tedgectl support reading from `/etc/tedgectl/env` to allow users to  enforce a specific package manager (to disable the auto detection of the service manager).