### PR TITLE
fix: set /etc/tedge ownership to prevent prevent the ownership from changing to root which causes startup problems

### DIFF
--- a/packages/openrc/nfpm.yaml
+++ b/packages/openrc/nfpm.yaml
@@ -36,10 +36,18 @@ contents:
     file_info:
       mode: 0644
 
+  # required otherwise the original dir permissions are overridden
+  - dst: /etc/tedge
+    type: dir
+    file_info:
+      owner: tedge
+      mode: 0775
+
   - src: ./services/system.toml
     dst: /etc/tedge/system.toml
     type: config
     file_info:
+      owner: tedge
       mode: 0644
 
 scripts:

--- a/packages/runit/nfpm.yaml
+++ b/packages/runit/nfpm.yaml
@@ -29,10 +29,18 @@ contents:
     file_info:
       mode: 0644
 
+  # required otherwise the original dir permissions are overridden
+  - dst: /etc/tedge
+    type: dir
+    file_info:
+      owner: tedge
+      mode: 0775
+
   - src: ./services/system.toml
     dst: /etc/tedge/system.toml
     type: config
     file_info:
+      owner: tedge
       mode: 0644
 
 scripts:

--- a/packages/s6-overlay/nfpm.yaml
+++ b/packages/s6-overlay/nfpm.yaml
@@ -29,10 +29,18 @@ contents:
     file_info:
       mode: 0644
 
+  # required otherwise the original dir permissions are overridden
+  - dst: /etc/tedge
+    type: dir
+    file_info:
+      owner: tedge
+      mode: 0775
+
   - src: ./services/system.toml
     dst: /etc/tedge/system.toml
     type: config
     file_info:
+      owner: tedge
       mode: 0644
 
 scripts:

--- a/packages/supervisord/nfpm.yaml
+++ b/packages/supervisord/nfpm.yaml
@@ -31,10 +31,18 @@ contents:
     file_info:
       mode: 0644
 
+  # required otherwise the original dir permissions are overridden
+  - dst: /etc/tedge
+    type: dir
+    file_info:
+      owner: tedge
+      mode: 0775
+
   - src: ./services/system.toml
     dst: /etc/tedge/system.toml
     type: config
     file_info:
+      owner: tedge
       mode: 0644
 
 scripts:

--- a/packages/sysvinit-yocto/nfpm.yaml
+++ b/packages/sysvinit-yocto/nfpm.yaml
@@ -31,10 +31,18 @@ contents:
     file_info:
       mode: 0644
 
+  # required otherwise the original dir permissions are overridden
+  - dst: /etc/tedge
+    type: dir
+    file_info:
+      owner: tedge
+      mode: 0775
+
   - src: ./services/system.toml
     dst: /etc/tedge/system.toml
     type: config
     file_info:
+      owner: tedge
       mode: 0644
 
 scripts:

--- a/packages/sysvinit/nfpm.yaml
+++ b/packages/sysvinit/nfpm.yaml
@@ -31,10 +31,18 @@ contents:
     file_info:
       mode: 0644
 
+  # required otherwise the original dir permissions are overridden
+  - dst: /etc/tedge
+    type: dir
+    file_info:
+      owner: tedge
+      mode: 0775
+
   - src: ./services/system.toml
     dst: /etc/tedge/system.toml
     type: config
     file_info:
+      owner: tedge
       mode: 0644
 
 scripts:


### PR DESCRIPTION
Fixing a bug which results in the ownership of the `/etc/tedge` folder being overwritten due to the inclusion of the `/etc/tedge/system.toml` file.

The `/etc/tedge` directory is included in the package definition to reflect the existing permissions used by `tedge init` until a better solution is found.