### PR TITLE
chore(install): minor install script improvements to log messages

### DIFF
--- a/install-services.sh
+++ b/install-services.sh
@@ -359,13 +359,13 @@ main() {
         echo "You can manage the services via the tedgectl utility"
         echo
         echo "Enable a service"
-        echo "  tedgectl enable mosquitto"
+        echo "  tedgectl enable <service>"
         echo
         echo "Start a service"
-        echo "  tedgectl start mosquitto"
+        echo "  tedgectl start <service>"
         echo
         echo "Stop a service"
-        echo "  tedgectl stop mosquitto"
+        echo "  tedgectl stop <service>"
         echo
         echo "You can go to our documentation to find next steps: https://thin-edge.github.io/thin-edge.io/start/getting-started"
     fi

--- a/install-services.sh
+++ b/install-services.sh
@@ -41,7 +41,7 @@ print_debug() {
     echo
     echo "--------------- machine details ---------------------"
     echo "date:           $(date || true)"
-    echo "tedge:          $VERSION"
+    echo "tedge:          $(tedge --version 2>/dev/null || true)"
     echo "Machine:        $(uname -a || true)"
     echo "Architecture:   $(dpkg --print-architecture 2>/dev/null || true)"
     if command_exists "lsb_release"; then


### PR DESCRIPTION
Minor improvements to log messages:

* show tedge version in the debug information
* show generic tedgectl usage instead of for just mosquitto (as that can be misleading if the user does not have mosquitto installed)