### PR TITLE
fix(version): fix release candidate version syntax

### DIFF
--- a/packages/openrc/nfpm.yaml
+++ b/packages/openrc/nfpm.yaml
@@ -4,6 +4,7 @@ name: tedge-openrc
 arch: all
 platform: linux
 version: ${SEMVER}
+release: ${RELEASE}
 section: misc
 priority: optional
 maintainer: thin-edge.io <thin-edge@thin-edge.io>

--- a/packages/runit/nfpm.yaml
+++ b/packages/runit/nfpm.yaml
@@ -4,6 +4,7 @@ name: tedge-runit
 arch: all
 platform: linux
 version: ${SEMVER}
+release: ${RELEASE}
 section: misc
 priority: optional
 maintainer: thin-edge.io <thin-edge@thin-edge.io>

--- a/packages/s6-overlay/nfpm.yaml
+++ b/packages/s6-overlay/nfpm.yaml
@@ -4,6 +4,7 @@ name: tedge-s6overlay
 arch: all
 platform: linux
 version: ${SEMVER}
+release: ${RELEASE}
 section: misc
 priority: optional
 maintainer: thin-edge.io <thin-edge@thin-edge.io>

--- a/packages/supervisord/nfpm.yaml
+++ b/packages/supervisord/nfpm.yaml
@@ -4,6 +4,7 @@ name: tedge-supervisord
 arch: all
 platform: linux
 version: ${SEMVER}
+release: ${RELEASE}
 section: misc
 priority: optional
 maintainer: thin-edge.io <thin-edge@thin-edge.io>

--- a/packages/sysvinit-yocto/nfpm.yaml
+++ b/packages/sysvinit-yocto/nfpm.yaml
@@ -4,6 +4,7 @@ name: tedge-sysvinit-yocto
 arch: all
 platform: linux
 version: ${SEMVER}
+release: ${RELEASE}
 section: misc
 priority: optional
 maintainer: thin-edge.io <thin-edge@thin-edge.io>

--- a/packages/sysvinit/nfpm.yaml
+++ b/packages/sysvinit/nfpm.yaml
@@ -4,6 +4,7 @@ name: tedge-sysvinit
 arch: all
 platform: linux
 version: ${SEMVER}
+release: ${RELEASE}
 section: misc
 priority: optional
 maintainer: thin-edge.io <thin-edge@thin-edge.io>


### PR DESCRIPTION
Fix a bug where the release candidate versioning syntax would cause a problem with the "latest" package detection in the tarball and linux packaging.