### PR TITLE
feat(s6-overlay): support enabling/disabling a service via env variables

### DIFF
--- a/services/generate.sh
+++ b/services/generate.sh
@@ -13,6 +13,7 @@ execute_template() {
         -e "s|\\\$COMMAND_ARGS|${COMMAND_ARGS:-}|g" \
         -e "s|\\\$COMMAND_USER|${COMMAND_USER:-}|g" \
         -e "s|\\\$COMMAND|${COMMAND:-}|g" \
+        -e "s|\\\$ENV_ENABLE_SERVICE|${ENV_ENABLE_SERVICE:-}|g" \
         -e "s|\\\$SHORTNAME|${SHORTNAME:-}|g" \
         -e "s|\\\$DESCRIPTION|${DESCRIPTION:-}|g" \
         "$input_file"
@@ -27,6 +28,7 @@ execute_template_inplace() {
         -e "s|\\\$COMMAND_ARGS|${COMMAND_ARGS:-}|g" \
         -e "s|\\\$COMMAND_USER|${COMMAND_USER:-}|g" \
         -e "s|\\\$COMMAND|${COMMAND:-}|g" \
+        -e "s|\\\$ENV_ENABLE_SERVICE|${ENV_ENABLE_SERVICE:-}|g" \
         -e "s|\\\$SHORTNAME|${SHORTNAME:-}|g" \
         -e "s|\\\$DESCRIPTION|${DESCRIPTION:-}|g" \
         "$input_file"

--- a/services/s6-overlay/s6-rc.d/c8y-configuration-plugin/run
+++ b/services/s6-overlay/s6-rc.d/c8y-configuration-plugin/run
@@ -1,3 +1,10 @@
 #!/command/with-contenv sh
+if [ "${SERVICE_C8Y_CONFIGURATION_PLUGIN:-1}" -eq 0 ]; then
+    # Disable service and don't start again
+    # https://github.com/just-containers/s6-overlay/issues/394
+    s6-svc -O .
+    exit 0
+fi
+
 exec 2>&1
 exec /usr/bin/c8y-configuration-plugin 

--- a/services/s6-overlay/s6-rc.d/c8y-firmware-plugin/run
+++ b/services/s6-overlay/s6-rc.d/c8y-firmware-plugin/run
@@ -1,3 +1,10 @@
 #!/command/with-contenv sh
+if [ "${SERVICE_C8Y_FIRMWARE_PLUGIN:-1}" -eq 0 ]; then
+    # Disable service and don't start again
+    # https://github.com/just-containers/s6-overlay/issues/394
+    s6-svc -O .
+    exit 0
+fi
+
 exec 2>&1
 exec /usr/bin/c8y-firmware-plugin 

--- a/services/s6-overlay/s6-rc.d/mosquitto/run
+++ b/services/s6-overlay/s6-rc.d/mosquitto/run
@@ -1,3 +1,10 @@
 #!/command/with-contenv sh
+if [ "${SERVICE_MOSQUITTO:-1}" -eq 0 ]; then
+    # Disable service and don't start again
+    # https://github.com/just-containers/s6-overlay/issues/394
+    s6-svc -O .
+    exit 0
+fi
+
 exec 2>&1
 exec /usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf

--- a/services/s6-overlay/s6-rc.d/tedge-agent/run
+++ b/services/s6-overlay/s6-rc.d/tedge-agent/run
@@ -1,3 +1,10 @@
 #!/command/with-contenv sh
+if [ "${SERVICE_TEDGE_AGENT:-1}" -eq 0 ]; then
+    # Disable service and don't start again
+    # https://github.com/just-containers/s6-overlay/issues/394
+    s6-svc -O .
+    exit 0
+fi
+
 exec 2>&1
 exec /usr/bin/tedge-agent 

--- a/services/s6-overlay/s6-rc.d/tedge-log-plugin/run
+++ b/services/s6-overlay/s6-rc.d/tedge-log-plugin/run
@@ -1,3 +1,10 @@
 #!/command/with-contenv sh
+if [ "${SERVICE_TEDGE_LOG_PLUGIN:-1}" -eq 0 ]; then
+    # Disable service and don't start again
+    # https://github.com/just-containers/s6-overlay/issues/394
+    s6-svc -O .
+    exit 0
+fi
+
 exec 2>&1
 exec /usr/bin/tedge-log-plugin 

--- a/services/s6-overlay/s6-rc.d/tedge-mapper-aws/run
+++ b/services/s6-overlay/s6-rc.d/tedge-mapper-aws/run
@@ -1,3 +1,10 @@
 #!/command/with-contenv sh
+if [ "${SERVICE_TEDGE_MAPPER_AWS:-1}" -eq 0 ]; then
+    # Disable service and don't start again
+    # https://github.com/just-containers/s6-overlay/issues/394
+    s6-svc -O .
+    exit 0
+fi
+
 exec 2>&1
 exec /usr/bin/tedge-mapper aws

--- a/services/s6-overlay/s6-rc.d/tedge-mapper-az/run
+++ b/services/s6-overlay/s6-rc.d/tedge-mapper-az/run
@@ -1,3 +1,10 @@
 #!/command/with-contenv sh
+if [ "${SERVICE_TEDGE_MAPPER_AZ:-1}" -eq 0 ]; then
+    # Disable service and don't start again
+    # https://github.com/just-containers/s6-overlay/issues/394
+    s6-svc -O .
+    exit 0
+fi
+
 exec 2>&1
 exec /usr/bin/tedge-mapper az

--- a/services/s6-overlay/s6-rc.d/tedge-mapper-c8y/run
+++ b/services/s6-overlay/s6-rc.d/tedge-mapper-c8y/run
@@ -1,3 +1,10 @@
 #!/command/with-contenv sh
+if [ "${SERVICE_TEDGE_MAPPER_C8Y:-1}" -eq 0 ]; then
+    # Disable service and don't start again
+    # https://github.com/just-containers/s6-overlay/issues/394
+    s6-svc -O .
+    exit 0
+fi
+
 exec 2>&1
 exec /usr/bin/tedge-mapper c8y

--- a/services/s6-overlay/s6-rc.d/tedge-mapper-collectd/run
+++ b/services/s6-overlay/s6-rc.d/tedge-mapper-collectd/run
@@ -1,3 +1,10 @@
 #!/command/with-contenv sh
+if [ "${SERVICE_TEDGE_MAPPER_COLLECTD:-1}" -eq 0 ]; then
+    # Disable service and don't start again
+    # https://github.com/just-containers/s6-overlay/issues/394
+    s6-svc -O .
+    exit 0
+fi
+
 exec 2>&1
 exec /usr/bin/tedge-mapper collectd

--- a/services/s6-overlay/templates/service/run
+++ b/services/s6-overlay/templates/service/run
@@ -1,3 +1,10 @@
 #!/command/with-contenv sh
+if [ "${$ENV_ENABLE_SERVICE:-1}" -eq 0 ]; then
+    # Disable service and don't start again
+    # https://github.com/just-containers/s6-overlay/issues/394
+    s6-svc -O .
+    exit 0
+fi
+
 exec 2>&1
 exec $COMMAND $COMMAND_ARGS

--- a/services/template-input/mosquitto
+++ b/services/template-input/mosquitto
@@ -2,6 +2,7 @@ NAME=mosquitto
 COMMAND=/usr/sbin/mosquitto
 COMMAND_ARGS="-c /etc/mosquitto/mosquitto.conf"
 COMMAND_USER=root
+ENV_ENABLE_SERVICE=SERVICE_MOSQUITTO
 DESCRIPTION="MQTT broker"
 SHORTNAME=mosquitto
 

--- a/services/template-input/tedge-agent
+++ b/services/template-input/tedge-agent
@@ -3,4 +3,5 @@ COMMAND=/usr/bin/tedge-agent
 COMMAND_USER=
 COMMAND_ARGS=
 COMMAND_USER=tedge
+ENV_ENABLE_SERVICE=SERVICE_TEDGE_AGENT
 DESCRIPTION="tedge-agent is a thin-edge.io component to support operations"

--- a/services/template-input/tedge-configuration-plugin
+++ b/services/template-input/tedge-configuration-plugin
@@ -2,4 +2,5 @@ NAME=c8y-configuration-plugin
 COMMAND=/usr/bin/c8y-configuration-plugin
 #COMMAND_ARGS=
 COMMAND_USER=root
+ENV_ENABLE_SERVICE=SERVICE_C8Y_CONFIGURATION_PLUGIN
 DESCRIPTION="Thin-edge device configuration management for Cumulocity"

--- a/services/template-input/tedge-firmware-plugin
+++ b/services/template-input/tedge-firmware-plugin
@@ -2,4 +2,5 @@ NAME=c8y-firmware-plugin
 COMMAND=/usr/bin/c8y-firmware-plugin
 #COMMAND_ARGS=
 COMMAND_USER=tedge
+ENV_ENABLE_SERVICE=SERVICE_C8Y_FIRMWARE_PLUGIN
 DESCRIPTION="Thin-edge device firmware management for Cumulocity"

--- a/services/template-input/tedge-log-plugin
+++ b/services/template-input/tedge-log-plugin
@@ -2,4 +2,5 @@ NAME=tedge-log-plugin
 COMMAND=/usr/bin/tedge-log-plugin
 #COMMAND_ARGS=
 COMMAND_USER=root
+ENV_ENABLE_SERVICE=SERVICE_TEDGE_LOG_PLUGIN
 DESCRIPTION="thin-edge.io log file retriever"

--- a/services/template-input/tedge-mapper-aws
+++ b/services/template-input/tedge-mapper-aws
@@ -2,5 +2,6 @@ NAME=tedge-mapper-aws
 COMMAND=/usr/bin/tedge-mapper
 COMMAND_ARGS=aws
 COMMAND_USER=tedge
+ENV_ENABLE_SERVICE=SERVICE_TEDGE_MAPPER_AWS
 DESCRIPTION="tedge-mapper-aws checks Thin Edge JSON measurements and forwards to AWS IoT Hub"
 SHORTNAME=mapper-aws

--- a/services/template-input/tedge-mapper-az
+++ b/services/template-input/tedge-mapper-az
@@ -2,5 +2,6 @@ NAME=tedge-mapper-az
 COMMAND=/usr/bin/tedge-mapper
 COMMAND_ARGS=az
 COMMAND_USER=tedge
+ENV_ENABLE_SERVICE=SERVICE_TEDGE_MAPPER_AZ
 DESCRIPTION="tedge-mapper-az checks Thin Edge JSON measurements and forwards to Azure IoT Hub"
 SHORTNAME=mapper-az

--- a/services/template-input/tedge-mapper-c8y
+++ b/services/template-input/tedge-mapper-c8y
@@ -2,5 +2,6 @@ NAME=tedge-mapper-c8y
 COMMAND=/usr/bin/tedge-mapper
 COMMAND_ARGS=c8y
 COMMAND_USER=tedge
+ENV_ENABLE_SERVICE=SERVICE_TEDGE_MAPPER_C8Y
 DESCRIPTION="tedge-mapper-c8y converts Thin Edge JSON measurements to Cumulocity JSON format"
 SHORTNAME=mapper-c8y

--- a/services/template-input/tedge-mapper-collectd
+++ b/services/template-input/tedge-mapper-collectd
@@ -2,5 +2,6 @@ NAME=tedge-mapper-collectd
 COMMAND=/usr/bin/tedge-mapper
 COMMAND_ARGS=collectd
 COMMAND_USER=tedge
+ENV_ENABLE_SERVICE=SERVICE_TEDGE_MAPPER_COLLECTD
 DESCRIPTION="tedge-mapper-collectd converts Thin Edge JSON measurements to Cumulocity JSON format"
 SHORTNAME=mapper-collectd


### PR DESCRIPTION
Support enabling/disabling the s6-overlay services via environment variables. Default is to have all services enabled.

You can then control which services start/stop:

The following environment variables would:

* enable c8y-configuration-plugin
* disable tedge-log-plugin

```
SERVICE_C8Y_CONFIGURATION_PLUGIN=0
SERVICE_TEDGE_LOG_PLUGIN=1
```

This feature is required until the thin-edge.io consolidates the multiple device management services into one single binary and is able to control which functions are enabled via configuration/env variables.