### PR TITLE
feat: add systemd service definitions for usage within yocto

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -123,6 +123,7 @@ if [ -n "$OUTPUT_DIR" ] && [ "$OUTPUT_DIR" != "." ] && [ "$OUTPUT_DIR" != ".." ]
 fi
 
 # Build packages for each init system
+build ./packages/systemd/nfpm.yaml "$OUTPUT_DIR"
 build ./packages/sysvinit/nfpm.yaml "$OUTPUT_DIR"
 build ./packages/sysvinit-yocto/nfpm.yaml "$OUTPUT_DIR"
 build ./packages/openrc/nfpm.yaml "$OUTPUT_DIR"

--- a/packages/systemd/nfpm.yaml
+++ b/packages/systemd/nfpm.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://nfpm.goreleaser.com/static/schema.json
+---
+name: tedge-systemd
+arch: all
+platform: linux
+version: ${SEMVER}
+release: ${RELEASE}
+section: misc
+priority: optional
+maintainer: thin-edge.io <thin-edge@thin-edge.io>
+description: thin-edge.io systemd service definitions
+vendor: thin-edge.io
+homepage: https://github.com/thin-edge/thin-edge.io
+license: Apache License 2.0
+apk:
+  # Use noarch instead of "all"
+  arch: noarch
+contents:
+  - src: ./services/systemd/system/*
+    dst: /lib/systemd/system/
+    file_info:
+      mode: 0644
+
+  - src: ./services/tedgectl
+    dst: /usr/bin/
+    file_info:
+      mode: 0755
+
+  - src: ./services/tedgectl_env
+    dst: /etc/tedgectl/env
+    type: config
+    file_info:
+      mode: 0644
+
+  # required otherwise the original dir permissions are overridden
+  - dst: /etc/tedge
+    type: dir
+    file_info:
+      owner: tedge
+      mode: 0775
+
+  # exclude as thin-edge.io support systemd out of the box
+  # - src: ./services/system.toml
+  #   dst: /etc/tedge/system.toml
+  #   type: config
+  #   file_info:
+  #     owner: tedge
+  #     mode: 0644
+
+scripts:
+  postinstall: ./packages/_scripts/postinstall.sh
+  preremove: ./packages/_scripts/preremove.sh

--- a/services/generate.sh
+++ b/services/generate.sh
@@ -48,6 +48,13 @@ generate_openrc() {
     chmod a+x "openrc/init.d/$NAME"
 }
 
+generate_systemd() {
+    mkdir -p systemd/system
+    echo "[sysvinit] Generating service file: $NAME"
+    execute_template "systemd/service.template" > "systemd/system/$NAME.service"
+    chmod a+x "systemd/system/$NAME.service"
+}
+
 generate_sysvinit() {
     mkdir -p sysvinit/init.d
     echo "[sysvinit] Generating service file: $NAME"
@@ -125,7 +132,7 @@ do
         SHORTNAME="${SHORTNAME:-$COMMAND}"
 
         if [ -z "$TEMPLATE_FOR" ]; then
-            TEMPLATE_FOR="openrc sysvinit sysvinit s6_overlay runit supervisord"
+            TEMPLATE_FOR="systemd openrc sysvinit sysvinit s6_overlay runit supervisord"
         fi
 
         # Validate mandatory arguments
@@ -134,6 +141,9 @@ do
 
             for template_name in $TEMPLATE_FOR; do
                 case "$template_name" in
+                    systemd)
+                        generate_systemd
+                        ;;
                     openrc)
                         generate_openrc
                         ;;

--- a/services/systemd/service.template
+++ b/services/systemd/service.template
@@ -1,0 +1,14 @@
+[Unit]
+Description=$DESCRIPTION
+After=syslog.target network.target mosquitto.service
+
+[Service]
+User=$COMMAND_USER
+RuntimeDirectory=$NAME
+ExecStart=$COMMAND $COMMAND_ARGS
+Restart=on-failure
+RestartPreventExitStatus=255
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/services/systemd/system/c8y-firmware-plugin.service
+++ b/services/systemd/system/c8y-firmware-plugin.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Thin-edge device firmware management for Cumulocity
+After=syslog.target network.target mosquitto.service
+
+[Service]
+User=tedge
+RuntimeDirectory=c8y-firmware-plugin
+ExecStart=/usr/bin/c8y-firmware-plugin 
+Restart=on-failure
+RestartPreventExitStatus=255
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/services/systemd/system/tedge-agent.service
+++ b/services/systemd/system/tedge-agent.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=tedge-agent is a thin-edge.io component to support operations
+After=syslog.target network.target mosquitto.service
+
+[Service]
+User=tedge
+RuntimeDirectory=tedge-agent
+ExecStart=/usr/bin/tedge-agent 
+Restart=on-failure
+RestartPreventExitStatus=255
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/services/systemd/system/tedge-configuration-plugin.service
+++ b/services/systemd/system/tedge-configuration-plugin.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Thin-edge device configuration management
+After=syslog.target network.target mosquitto.service
+
+[Service]
+User=root
+RuntimeDirectory=tedge-configuration-plugin
+ExecStart=/usr/bin/tedge-configuration-plugin 
+Restart=on-failure
+RestartPreventExitStatus=255
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/services/systemd/system/tedge-log-plugin.service
+++ b/services/systemd/system/tedge-log-plugin.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=thin-edge.io log file retriever
+After=syslog.target network.target mosquitto.service
+
+[Service]
+User=root
+RuntimeDirectory=tedge-log-plugin
+ExecStart=/usr/bin/tedge-log-plugin 
+Restart=on-failure
+RestartPreventExitStatus=255
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/services/systemd/system/tedge-mapper-aws.service
+++ b/services/systemd/system/tedge-mapper-aws.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=tedge-mapper-aws checks Thin Edge JSON measurements and forwards to AWS IoT Hub
+After=syslog.target network.target mosquitto.service
+
+[Service]
+User=tedge
+RuntimeDirectory=tedge-mapper-aws
+ExecStart=/usr/bin/tedge-mapper aws
+Restart=on-failure
+RestartPreventExitStatus=255
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/services/systemd/system/tedge-mapper-az.service
+++ b/services/systemd/system/tedge-mapper-az.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=tedge-mapper-az checks Thin Edge JSON measurements and forwards to Azure IoT Hub
+After=syslog.target network.target mosquitto.service
+
+[Service]
+User=tedge
+RuntimeDirectory=tedge-mapper-az
+ExecStart=/usr/bin/tedge-mapper az
+Restart=on-failure
+RestartPreventExitStatus=255
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/services/systemd/system/tedge-mapper-c8y.service
+++ b/services/systemd/system/tedge-mapper-c8y.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=tedge-mapper-c8y converts Thin Edge JSON measurements to Cumulocity JSON format
+After=syslog.target network.target mosquitto.service
+
+[Service]
+User=tedge
+RuntimeDirectory=tedge-mapper-c8y
+ExecStart=/usr/bin/tedge-mapper c8y
+Restart=on-failure
+RestartPreventExitStatus=255
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/services/systemd/system/tedge-mapper-collectd.service
+++ b/services/systemd/system/tedge-mapper-collectd.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=tedge-mapper-collectd converts Thin Edge JSON measurements to Cumulocity JSON format
+After=syslog.target network.target mosquitto.service
+
+[Service]
+User=tedge
+RuntimeDirectory=tedge-mapper-collectd
+ExecStart=/usr/bin/tedge-mapper collectd
+Restart=on-failure
+RestartPreventExitStatus=255
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Provide systemd service definitions to easy the installation within yocto builds where installing the official packages difficult or not possible.

For normal installations the thin-edge.io official deb, rpm and apk packages should still be preferred.