### PR TITLE
feat: run service pre start initializations

### DIFF
--- a/services/openrc/init.d.template
+++ b/services/openrc/init.d.template
@@ -10,6 +10,7 @@ error_log="${TEDGE_LOGFILE}"
 
 start_pre()
 {
+    tedge init ||:
     if [ -n "$COMMAND_USER" ]; then
         checkpath --file --owner "$COMMAND_USER" "$TEDGE_LOGFILE"
     fi

--- a/services/runit/run.template
+++ b/services/runit/run.template
@@ -7,6 +7,7 @@ PIDFILE="/run/lock/$NAME.lock"
 mkdir -p /run/lock
 chown 1777 /run/lock
 touch "$PIDFILE"
+tedge init ||:
 
 if [ -n "$DAEMON_USER" ]; then
     chown "$DAEMON_USER" "$PIDFILE"

--- a/services/s6-overlay/templates/service/run
+++ b/services/s6-overlay/templates/service/run
@@ -5,6 +5,7 @@ if [ "${$ENV_ENABLE_SERVICE:-1}" -eq 0 ]; then
     s6-svc -O .
     exit 0
 fi
+tedge init ||:
 
 exec 2>&1
 exec $COMMAND $COMMAND_ARGS

--- a/services/supervisord/service.template
+++ b/services/supervisord/service.template
@@ -1,5 +1,5 @@
 [program:$NAME]
-command=$COMMAND $COMMAND_ARGS
+command=/bin/sh -c "tedge init ||:; $COMMAND $COMMAND_ARGS"
 user=$COMMAND_USER
 startsecs=5
 autostart=true

--- a/services/systemd/service.template
+++ b/services/systemd/service.template
@@ -5,6 +5,7 @@ After=syslog.target network.target mosquitto.service
 [Service]
 User=$COMMAND_USER
 RuntimeDirectory=$NAME
+ExecStartPre=+-/usr/bin/tedge init
 ExecStart=$COMMAND $COMMAND_ARGS
 Restart=on-failure
 RestartPreventExitStatus=255

--- a/services/sysvinit-yocto/service-background.template
+++ b/services/sysvinit-yocto/service-background.template
@@ -74,6 +74,7 @@ case "$1" in
             echo "Already started"
         else
             echo "Starting $name (using '$SUDO $DAEMON $DAEMON_ARGS')"
+            tedge init ||:
             cd "$dir" || (echo "Failed changing directory"; exit 1)
             $SUDO $DAEMON $DAEMON_ARGS >> "$stdout_log" 2>> "$stderr_log" &
             # TODO: is it ok to let the process create the pidfile itself?

--- a/services/sysvinit-yocto/service-yocto.template
+++ b/services/sysvinit-yocto/service-yocto.template
@@ -94,6 +94,7 @@ do_start() {
 		;;
 	*)
 		echo "Starting $DESC ..."
+		tedge init ||:
 		exec $DAEMON $DAEMON_ARGS >/dev/null 2>&1 || status=$?
 		echo "ERROR: Failed to start $DESC."
 		exit $status

--- a/services/sysvinit/service-nondeps.template
+++ b/services/sysvinit/service-nondeps.template
@@ -52,6 +52,7 @@ case "$1" in
           echo "Already started"
       else
           echo "Starting $name (using '$SUDO $DAEMON $DAEMON_ARGS')"
+          tedge init ||:
           cd "$dir" || (echo "Failed changing directory"; exit 1)
           $SUDO $DAEMON $DAEMON_ARGS >> "$stdout_log" 2>> "$stderr_log" &
           # TODO: is it ok to let the process create the pidfile itself?

--- a/services/sysvinit/service-start-stop-daemon.template
+++ b/services/sysvinit/service-start-stop-daemon.template
@@ -76,6 +76,7 @@ do_start() {
     if [ $run_service = 1 ]
     then
         log_begin_msg "Starting $NAME daemon..."
+        tedge init ||:
 
         # Create log file with given user so it can write to it (for non-root users)
         touch "$LOG_FILE"


### PR DESCRIPTION
Running the initializations before starting the service ensure that the required filesystem elements exist before starting the service. This is useful when the /var/log folder is mounted to a volatile partition