### PR TITLE
feat(sysvinit): improve detection of sysvinit when update-rc.d is not installed

### DIFF
--- a/services/tedgectl
+++ b/services/tedgectl
@@ -20,6 +20,9 @@ if [ -z "$SERVICE_MANAGER" ]; then
         SERVICE_MANAGER="openrc"
     elif command -V update-rc.d >/dev/null 2>&1; then
         SERVICE_MANAGER="sysvinit"
+    elif command -V /sbin/init >/dev/null 2>&1 && /sbin/init --version >/dev/null 2>&1; then
+        # systemv init without update-rc.d
+        SERVICE_MANAGER="sysvinit"
     elif [ -f /command/s6-rc ]; then
         SERVICE_MANAGER="s6_overlay"
     elif command -V runsv >/dev/null 2>&1; then


### PR DESCRIPTION
Improve the sysvinit service control on linux distributions that use SysVInit but don't use update-rc.d (e.g. Yocto based distributions).