### PR TITLE
fix(sysvinit): fix service status check by using status_of_proc

### DIFF
--- a/services/sysvinit-yocto/init.d/c8y-firmware-plugin
+++ b/services/sysvinit-yocto/init.d/c8y-firmware-plugin
@@ -74,6 +74,7 @@ case "$1" in
             echo "Already started"
         else
             echo "Starting $name (using '$SUDO $DAEMON $DAEMON_ARGS')"
+            tedge init ||:
             cd "$dir" || (echo "Failed changing directory"; exit 1)
             $SUDO $DAEMON $DAEMON_ARGS >> "$stdout_log" 2>> "$stderr_log" &
             # TODO: is it ok to let the process create the pidfile itself?

--- a/services/sysvinit/init.d/c8y-firmware-plugin
+++ b/services/sysvinit/init.d/c8y-firmware-plugin
@@ -76,6 +76,7 @@ do_start() {
     if [ $run_service = 1 ]
     then
         log_begin_msg "Starting c8y-firmware-plugin daemon..."
+        tedge init ||:
 
         # Create log file with given user so it can write to it (for non-root users)
         touch "$LOG_FILE"
@@ -130,7 +131,7 @@ case "$1" in
     ;;
 
   status)
-    status "$DAEMON"
+    status_of_proc -p "${PIDFILE}" "${DAEMON}" "c8y-firmware-plugin" && exit 0 || exit $?
     ;;
 
   *)

--- a/services/sysvinit/init.d/tedge-agent
+++ b/services/sysvinit/init.d/tedge-agent
@@ -76,6 +76,7 @@ do_start() {
     if [ $run_service = 1 ]
     then
         log_begin_msg "Starting tedge-agent daemon..."
+        tedge init ||:
 
         # Create log file with given user so it can write to it (for non-root users)
         touch "$LOG_FILE"
@@ -130,7 +131,7 @@ case "$1" in
     ;;
 
   status)
-    status "$DAEMON"
+    status_of_proc -p "${PIDFILE}" "${DAEMON}" "tedge-agent" && exit 0 || exit $?
     ;;
 
   *)

--- a/services/sysvinit/init.d/tedge-mapper-aws
+++ b/services/sysvinit/init.d/tedge-mapper-aws
@@ -76,6 +76,7 @@ do_start() {
     if [ $run_service = 1 ]
     then
         log_begin_msg "Starting tedge-mapper-aws daemon..."
+        tedge init ||:
 
         # Create log file with given user so it can write to it (for non-root users)
         touch "$LOG_FILE"
@@ -130,7 +131,7 @@ case "$1" in
     ;;
 
   status)
-    status "$DAEMON"
+    status_of_proc -p "${PIDFILE}" "${DAEMON}" "tedge-mapper-aws" && exit 0 || exit $?
     ;;
 
   *)

--- a/services/sysvinit/init.d/tedge-mapper-az
+++ b/services/sysvinit/init.d/tedge-mapper-az
@@ -76,6 +76,7 @@ do_start() {
     if [ $run_service = 1 ]
     then
         log_begin_msg "Starting tedge-mapper-az daemon..."
+        tedge init ||:
 
         # Create log file with given user so it can write to it (for non-root users)
         touch "$LOG_FILE"
@@ -130,7 +131,7 @@ case "$1" in
     ;;
 
   status)
-    status "$DAEMON"
+    status_of_proc -p "${PIDFILE}" "${DAEMON}" "tedge-mapper-az" && exit 0 || exit $?
     ;;
 
   *)

--- a/services/sysvinit/init.d/tedge-mapper-c8y
+++ b/services/sysvinit/init.d/tedge-mapper-c8y
@@ -76,6 +76,7 @@ do_start() {
     if [ $run_service = 1 ]
     then
         log_begin_msg "Starting tedge-mapper-c8y daemon..."
+        tedge init ||:
 
         # Create log file with given user so it can write to it (for non-root users)
         touch "$LOG_FILE"
@@ -130,7 +131,7 @@ case "$1" in
     ;;
 
   status)
-    status "$DAEMON"
+    status_of_proc -p "${PIDFILE}" "${DAEMON}" "tedge-mapper-c8y" && exit 0 || exit $?
     ;;
 
   *)

--- a/services/sysvinit/init.d/tedge-mapper-collectd
+++ b/services/sysvinit/init.d/tedge-mapper-collectd
@@ -76,6 +76,7 @@ do_start() {
     if [ $run_service = 1 ]
     then
         log_begin_msg "Starting tedge-mapper-collectd daemon..."
+        tedge init ||:
 
         # Create log file with given user so it can write to it (for non-root users)
         touch "$LOG_FILE"
@@ -130,7 +131,7 @@ case "$1" in
     ;;
 
   status)
-    status "$DAEMON"
+    status_of_proc -p "${PIDFILE}" "${DAEMON}" "tedge-mapper-collectd" && exit 0 || exit $?
     ;;
 
   *)

--- a/services/sysvinit/service-start-stop-daemon.template
+++ b/services/sysvinit/service-start-stop-daemon.template
@@ -131,7 +131,7 @@ case "$1" in
     ;;
 
   status)
-    status "$DAEMON"
+    status_of_proc -p "${PIDFILE}" "${DAEMON}" "$NAME" && exit 0 || exit $?
     ;;
 
   *)


### PR DESCRIPTION
Fix the sysvinit `/etc/init.d/<service> status` function which was using an non-existent function. Now the `status_of_proc` lsb helper function is used.