### PR TITLE
feat(all): call tedge init before starting the service

### DIFF
--- a/services/openrc/init.d/c8y-firmware-plugin
+++ b/services/openrc/init.d/c8y-firmware-plugin
@@ -10,6 +10,7 @@ error_log="${TEDGE_LOGFILE}"
 
 start_pre()
 {
+    tedge init ||:
     if [ -n "tedge" ]; then
         checkpath --file --owner "tedge" "$TEDGE_LOGFILE"
     fi

--- a/services/openrc/init.d/tedge-agent
+++ b/services/openrc/init.d/tedge-agent
@@ -10,6 +10,7 @@ error_log="${TEDGE_LOGFILE}"
 
 start_pre()
 {
+    tedge init ||:
     if [ -n "tedge" ]; then
         checkpath --file --owner "tedge" "$TEDGE_LOGFILE"
     fi

--- a/services/openrc/init.d/tedge-mapper-aws
+++ b/services/openrc/init.d/tedge-mapper-aws
@@ -10,6 +10,7 @@ error_log="${TEDGE_LOGFILE}"
 
 start_pre()
 {
+    tedge init ||:
     if [ -n "tedge" ]; then
         checkpath --file --owner "tedge" "$TEDGE_LOGFILE"
     fi

--- a/services/openrc/init.d/tedge-mapper-az
+++ b/services/openrc/init.d/tedge-mapper-az
@@ -10,6 +10,7 @@ error_log="${TEDGE_LOGFILE}"
 
 start_pre()
 {
+    tedge init ||:
     if [ -n "tedge" ]; then
         checkpath --file --owner "tedge" "$TEDGE_LOGFILE"
     fi

--- a/services/openrc/init.d/tedge-mapper-c8y
+++ b/services/openrc/init.d/tedge-mapper-c8y
@@ -10,6 +10,7 @@ error_log="${TEDGE_LOGFILE}"
 
 start_pre()
 {
+    tedge init ||:
     if [ -n "tedge" ]; then
         checkpath --file --owner "tedge" "$TEDGE_LOGFILE"
     fi

--- a/services/openrc/init.d/tedge-mapper-collectd
+++ b/services/openrc/init.d/tedge-mapper-collectd
@@ -10,6 +10,7 @@ error_log="${TEDGE_LOGFILE}"
 
 start_pre()
 {
+    tedge init ||:
     if [ -n "tedge" ]; then
         checkpath --file --owner "tedge" "$TEDGE_LOGFILE"
     fi

--- a/services/runit/runsvdir/c8y-firmware-plugin/run
+++ b/services/runit/runsvdir/c8y-firmware-plugin/run
@@ -7,6 +7,7 @@ PIDFILE="/run/lock/c8y-firmware-plugin.lock"
 mkdir -p /run/lock
 chown 1777 /run/lock
 touch "$PIDFILE"
+tedge init ||:
 
 if [ -n "$DAEMON_USER" ]; then
     chown "$DAEMON_USER" "$PIDFILE"

--- a/services/runit/runsvdir/mosquitto/run
+++ b/services/runit/runsvdir/mosquitto/run
@@ -7,6 +7,7 @@ PIDFILE="/run/lock/mosquitto.lock"
 mkdir -p /run/lock
 chown 1777 /run/lock
 touch "$PIDFILE"
+tedge init ||:
 
 if [ -n "$DAEMON_USER" ]; then
     chown "$DAEMON_USER" "$PIDFILE"

--- a/services/runit/runsvdir/tedge-agent/run
+++ b/services/runit/runsvdir/tedge-agent/run
@@ -7,6 +7,7 @@ PIDFILE="/run/lock/tedge-agent.lock"
 mkdir -p /run/lock
 chown 1777 /run/lock
 touch "$PIDFILE"
+tedge init ||:
 
 if [ -n "$DAEMON_USER" ]; then
     chown "$DAEMON_USER" "$PIDFILE"

--- a/services/runit/runsvdir/tedge-mapper-aws/run
+++ b/services/runit/runsvdir/tedge-mapper-aws/run
@@ -7,6 +7,7 @@ PIDFILE="/run/lock/tedge-mapper-aws.lock"
 mkdir -p /run/lock
 chown 1777 /run/lock
 touch "$PIDFILE"
+tedge init ||:
 
 if [ -n "$DAEMON_USER" ]; then
     chown "$DAEMON_USER" "$PIDFILE"

--- a/services/runit/runsvdir/tedge-mapper-az/run
+++ b/services/runit/runsvdir/tedge-mapper-az/run
@@ -7,6 +7,7 @@ PIDFILE="/run/lock/tedge-mapper-az.lock"
 mkdir -p /run/lock
 chown 1777 /run/lock
 touch "$PIDFILE"
+tedge init ||:
 
 if [ -n "$DAEMON_USER" ]; then
     chown "$DAEMON_USER" "$PIDFILE"

--- a/services/runit/runsvdir/tedge-mapper-c8y/run
+++ b/services/runit/runsvdir/tedge-mapper-c8y/run
@@ -7,6 +7,7 @@ PIDFILE="/run/lock/tedge-mapper-c8y.lock"
 mkdir -p /run/lock
 chown 1777 /run/lock
 touch "$PIDFILE"
+tedge init ||:
 
 if [ -n "$DAEMON_USER" ]; then
     chown "$DAEMON_USER" "$PIDFILE"

--- a/services/runit/runsvdir/tedge-mapper-collectd/run
+++ b/services/runit/runsvdir/tedge-mapper-collectd/run
@@ -7,6 +7,7 @@ PIDFILE="/run/lock/tedge-mapper-collectd.lock"
 mkdir -p /run/lock
 chown 1777 /run/lock
 touch "$PIDFILE"
+tedge init ||:
 
 if [ -n "$DAEMON_USER" ]; then
     chown "$DAEMON_USER" "$PIDFILE"

--- a/services/s6-overlay/s6-rc.d/c8y-firmware-plugin/run
+++ b/services/s6-overlay/s6-rc.d/c8y-firmware-plugin/run
@@ -5,6 +5,7 @@ if [ "${SERVICE_C8Y_FIRMWARE_PLUGIN:-1}" -eq 0 ]; then
     s6-svc -O .
     exit 0
 fi
+tedge init ||:
 
 exec 2>&1
 exec /usr/bin/c8y-firmware-plugin 

--- a/services/s6-overlay/s6-rc.d/mosquitto/run
+++ b/services/s6-overlay/s6-rc.d/mosquitto/run
@@ -5,6 +5,7 @@ if [ "${SERVICE_MOSQUITTO:-1}" -eq 0 ]; then
     s6-svc -O .
     exit 0
 fi
+tedge init ||:
 
 exec 2>&1
 exec /usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf

--- a/services/s6-overlay/s6-rc.d/tedge-agent/run
+++ b/services/s6-overlay/s6-rc.d/tedge-agent/run
@@ -5,6 +5,7 @@ if [ "${SERVICE_TEDGE_AGENT:-1}" -eq 0 ]; then
     s6-svc -O .
     exit 0
 fi
+tedge init ||:
 
 exec 2>&1
 exec /usr/bin/tedge-agent 

--- a/services/s6-overlay/s6-rc.d/tedge-mapper-aws/run
+++ b/services/s6-overlay/s6-rc.d/tedge-mapper-aws/run
@@ -5,6 +5,7 @@ if [ "${SERVICE_TEDGE_MAPPER_AWS:-1}" -eq 0 ]; then
     s6-svc -O .
     exit 0
 fi
+tedge init ||:
 
 exec 2>&1
 exec /usr/bin/tedge-mapper aws

--- a/services/s6-overlay/s6-rc.d/tedge-mapper-az/run
+++ b/services/s6-overlay/s6-rc.d/tedge-mapper-az/run
@@ -5,6 +5,7 @@ if [ "${SERVICE_TEDGE_MAPPER_AZ:-1}" -eq 0 ]; then
     s6-svc -O .
     exit 0
 fi
+tedge init ||:
 
 exec 2>&1
 exec /usr/bin/tedge-mapper az

--- a/services/s6-overlay/s6-rc.d/tedge-mapper-c8y/run
+++ b/services/s6-overlay/s6-rc.d/tedge-mapper-c8y/run
@@ -5,6 +5,7 @@ if [ "${SERVICE_TEDGE_MAPPER_C8Y:-1}" -eq 0 ]; then
     s6-svc -O .
     exit 0
 fi
+tedge init ||:
 
 exec 2>&1
 exec /usr/bin/tedge-mapper c8y

--- a/services/s6-overlay/s6-rc.d/tedge-mapper-collectd/run
+++ b/services/s6-overlay/s6-rc.d/tedge-mapper-collectd/run
@@ -5,6 +5,7 @@ if [ "${SERVICE_TEDGE_MAPPER_COLLECTD:-1}" -eq 0 ]; then
     s6-svc -O .
     exit 0
 fi
+tedge init ||:
 
 exec 2>&1
 exec /usr/bin/tedge-mapper collectd

--- a/services/supervisord/conf.d/c8y-firmware-plugin.conf
+++ b/services/supervisord/conf.d/c8y-firmware-plugin.conf
@@ -1,5 +1,5 @@
 [program:c8y-firmware-plugin]
-command=/usr/bin/c8y-firmware-plugin 
+command=/bin/sh -c "tedge init ||:; /usr/bin/c8y-firmware-plugin "
 user=tedge
 startsecs=5
 autostart=true

--- a/services/supervisord/conf.d/mosquitto.conf
+++ b/services/supervisord/conf.d/mosquitto.conf
@@ -1,5 +1,5 @@
 [program:mosquitto]
-command=/usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf
+command=/bin/sh -c "tedge init ||:; /usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf"
 user=root
 startsecs=5
 autostart=true

--- a/services/supervisord/conf.d/tedge-agent.conf
+++ b/services/supervisord/conf.d/tedge-agent.conf
@@ -1,5 +1,5 @@
 [program:tedge-agent]
-command=/usr/bin/tedge-agent 
+command=/bin/sh -c "tedge init ||:; /usr/bin/tedge-agent "
 user=tedge
 startsecs=5
 autostart=true

--- a/services/supervisord/conf.d/tedge-mapper-aws.conf
+++ b/services/supervisord/conf.d/tedge-mapper-aws.conf
@@ -1,5 +1,5 @@
 [program:tedge-mapper-aws]
-command=/usr/bin/tedge-mapper aws
+command=/bin/sh -c "tedge init ||:; /usr/bin/tedge-mapper aws"
 user=tedge
 startsecs=5
 autostart=true

--- a/services/supervisord/conf.d/tedge-mapper-az.conf
+++ b/services/supervisord/conf.d/tedge-mapper-az.conf
@@ -1,5 +1,5 @@
 [program:tedge-mapper-az]
-command=/usr/bin/tedge-mapper az
+command=/bin/sh -c "tedge init ||:; /usr/bin/tedge-mapper az"
 user=tedge
 startsecs=5
 autostart=true

--- a/services/supervisord/conf.d/tedge-mapper-c8y.conf
+++ b/services/supervisord/conf.d/tedge-mapper-c8y.conf
@@ -1,5 +1,5 @@
 [program:tedge-mapper-c8y]
-command=/usr/bin/tedge-mapper c8y
+command=/bin/sh -c "tedge init ||:; /usr/bin/tedge-mapper c8y"
 user=tedge
 startsecs=5
 autostart=true

--- a/services/supervisord/conf.d/tedge-mapper-collectd.conf
+++ b/services/supervisord/conf.d/tedge-mapper-collectd.conf
@@ -1,5 +1,5 @@
 [program:tedge-mapper-collectd]
-command=/usr/bin/tedge-mapper collectd
+command=/bin/sh -c "tedge init ||:; /usr/bin/tedge-mapper collectd"
 user=tedge
 startsecs=5
 autostart=true

--- a/services/systemd/system/c8y-firmware-plugin.service
+++ b/services/systemd/system/c8y-firmware-plugin.service
@@ -5,6 +5,7 @@ After=syslog.target network.target mosquitto.service
 [Service]
 User=tedge
 RuntimeDirectory=c8y-firmware-plugin
+ExecStartPre=+-/usr/bin/tedge init
 ExecStart=/usr/bin/c8y-firmware-plugin 
 Restart=on-failure
 RestartPreventExitStatus=255

--- a/services/systemd/system/tedge-agent.service
+++ b/services/systemd/system/tedge-agent.service
@@ -5,6 +5,7 @@ After=syslog.target network.target mosquitto.service
 [Service]
 User=tedge
 RuntimeDirectory=tedge-agent
+ExecStartPre=+-/usr/bin/tedge init
 ExecStart=/usr/bin/tedge-agent 
 Restart=on-failure
 RestartPreventExitStatus=255

--- a/services/systemd/system/tedge-mapper-aws.service
+++ b/services/systemd/system/tedge-mapper-aws.service
@@ -5,6 +5,7 @@ After=syslog.target network.target mosquitto.service
 [Service]
 User=tedge
 RuntimeDirectory=tedge-mapper-aws
+ExecStartPre=+-/usr/bin/tedge init
 ExecStart=/usr/bin/tedge-mapper aws
 Restart=on-failure
 RestartPreventExitStatus=255

--- a/services/systemd/system/tedge-mapper-az.service
+++ b/services/systemd/system/tedge-mapper-az.service
@@ -5,6 +5,7 @@ After=syslog.target network.target mosquitto.service
 [Service]
 User=tedge
 RuntimeDirectory=tedge-mapper-az
+ExecStartPre=+-/usr/bin/tedge init
 ExecStart=/usr/bin/tedge-mapper az
 Restart=on-failure
 RestartPreventExitStatus=255

--- a/services/systemd/system/tedge-mapper-c8y.service
+++ b/services/systemd/system/tedge-mapper-c8y.service
@@ -5,6 +5,7 @@ After=syslog.target network.target mosquitto.service
 [Service]
 User=tedge
 RuntimeDirectory=tedge-mapper-c8y
+ExecStartPre=+-/usr/bin/tedge init
 ExecStart=/usr/bin/tedge-mapper c8y
 Restart=on-failure
 RestartPreventExitStatus=255

--- a/services/systemd/system/tedge-mapper-collectd.service
+++ b/services/systemd/system/tedge-mapper-collectd.service
@@ -5,6 +5,7 @@ After=syslog.target network.target mosquitto.service
 [Service]
 User=tedge
 RuntimeDirectory=tedge-mapper-collectd
+ExecStartPre=+-/usr/bin/tedge init
 ExecStart=/usr/bin/tedge-mapper collectd
 Restart=on-failure
 RestartPreventExitStatus=255

--- a/services/sysvinit-yocto/init.d/tedge-agent
+++ b/services/sysvinit-yocto/init.d/tedge-agent
@@ -74,6 +74,7 @@ case "$1" in
             echo "Already started"
         else
             echo "Starting $name (using '$SUDO $DAEMON $DAEMON_ARGS')"
+            tedge init ||:
             cd "$dir" || (echo "Failed changing directory"; exit 1)
             $SUDO $DAEMON $DAEMON_ARGS >> "$stdout_log" 2>> "$stderr_log" &
             # TODO: is it ok to let the process create the pidfile itself?

--- a/services/sysvinit-yocto/init.d/tedge-mapper-aws
+++ b/services/sysvinit-yocto/init.d/tedge-mapper-aws
@@ -74,6 +74,7 @@ case "$1" in
             echo "Already started"
         else
             echo "Starting $name (using '$SUDO $DAEMON $DAEMON_ARGS')"
+            tedge init ||:
             cd "$dir" || (echo "Failed changing directory"; exit 1)
             $SUDO $DAEMON $DAEMON_ARGS >> "$stdout_log" 2>> "$stderr_log" &
             # TODO: is it ok to let the process create the pidfile itself?

--- a/services/sysvinit-yocto/init.d/tedge-mapper-az
+++ b/services/sysvinit-yocto/init.d/tedge-mapper-az
@@ -74,6 +74,7 @@ case "$1" in
             echo "Already started"
         else
             echo "Starting $name (using '$SUDO $DAEMON $DAEMON_ARGS')"
+            tedge init ||:
             cd "$dir" || (echo "Failed changing directory"; exit 1)
             $SUDO $DAEMON $DAEMON_ARGS >> "$stdout_log" 2>> "$stderr_log" &
             # TODO: is it ok to let the process create the pidfile itself?

--- a/services/sysvinit-yocto/init.d/tedge-mapper-c8y
+++ b/services/sysvinit-yocto/init.d/tedge-mapper-c8y
@@ -74,6 +74,7 @@ case "$1" in
             echo "Already started"
         else
             echo "Starting $name (using '$SUDO $DAEMON $DAEMON_ARGS')"
+            tedge init ||:
             cd "$dir" || (echo "Failed changing directory"; exit 1)
             $SUDO $DAEMON $DAEMON_ARGS >> "$stdout_log" 2>> "$stderr_log" &
             # TODO: is it ok to let the process create the pidfile itself?

--- a/services/sysvinit-yocto/init.d/tedge-mapper-collectd
+++ b/services/sysvinit-yocto/init.d/tedge-mapper-collectd
@@ -74,6 +74,7 @@ case "$1" in
             echo "Already started"
         else
             echo "Starting $name (using '$SUDO $DAEMON $DAEMON_ARGS')"
+            tedge init ||:
             cd "$dir" || (echo "Failed changing directory"; exit 1)
             $SUDO $DAEMON $DAEMON_ARGS >> "$stdout_log" 2>> "$stderr_log" &
             # TODO: is it ok to let the process create the pidfile itself?


### PR DESCRIPTION
Ensure `tedge init` is called before starting any tedge service to ensure the filesystem has been initialized.