### PR TITLE
fix(sysvinit): during status check, fallback to status if status_of_proc is not available

### DIFF
--- a/services/sysvinit/init.d/c8y-firmware-plugin
+++ b/services/sysvinit/init.d/c8y-firmware-plugin
@@ -131,7 +131,11 @@ case "$1" in
     ;;
 
   status)
-    status_of_proc -p "${PIDFILE}" "${DAEMON}" "c8y-firmware-plugin" && exit 0 || exit $?
+    if command -V status_of_proc >/dev/null 2>&1; then
+        status_of_proc -p "${PIDFILE}" "${DAEMON}" "c8y-firmware-plugin" && exit 0 || exit $?
+    else
+        status "${DAEMON}" && exit 0 || exit $?
+    fi
     ;;
 
   *)

--- a/services/sysvinit/init.d/tedge-agent
+++ b/services/sysvinit/init.d/tedge-agent
@@ -131,7 +131,11 @@ case "$1" in
     ;;
 
   status)
-    status_of_proc -p "${PIDFILE}" "${DAEMON}" "tedge-agent" && exit 0 || exit $?
+    if command -V status_of_proc >/dev/null 2>&1; then
+        status_of_proc -p "${PIDFILE}" "${DAEMON}" "tedge-agent" && exit 0 || exit $?
+    else
+        status "${DAEMON}" && exit 0 || exit $?
+    fi
     ;;
 
   *)

--- a/services/sysvinit/init.d/tedge-mapper-aws
+++ b/services/sysvinit/init.d/tedge-mapper-aws
@@ -131,7 +131,11 @@ case "$1" in
     ;;
 
   status)
-    status_of_proc -p "${PIDFILE}" "${DAEMON}" "tedge-mapper-aws" && exit 0 || exit $?
+    if command -V status_of_proc >/dev/null 2>&1; then
+        status_of_proc -p "${PIDFILE}" "${DAEMON}" "tedge-mapper-aws" && exit 0 || exit $?
+    else
+        status "${DAEMON}" && exit 0 || exit $?
+    fi
     ;;
 
   *)

--- a/services/sysvinit/init.d/tedge-mapper-az
+++ b/services/sysvinit/init.d/tedge-mapper-az
@@ -131,7 +131,11 @@ case "$1" in
     ;;
 
   status)
-    status_of_proc -p "${PIDFILE}" "${DAEMON}" "tedge-mapper-az" && exit 0 || exit $?
+    if command -V status_of_proc >/dev/null 2>&1; then
+        status_of_proc -p "${PIDFILE}" "${DAEMON}" "tedge-mapper-az" && exit 0 || exit $?
+    else
+        status "${DAEMON}" && exit 0 || exit $?
+    fi
     ;;
 
   *)

--- a/services/sysvinit/init.d/tedge-mapper-c8y
+++ b/services/sysvinit/init.d/tedge-mapper-c8y
@@ -131,7 +131,11 @@ case "$1" in
     ;;
 
   status)
-    status_of_proc -p "${PIDFILE}" "${DAEMON}" "tedge-mapper-c8y" && exit 0 || exit $?
+    if command -V status_of_proc >/dev/null 2>&1; then
+        status_of_proc -p "${PIDFILE}" "${DAEMON}" "tedge-mapper-c8y" && exit 0 || exit $?
+    else
+        status "${DAEMON}" && exit 0 || exit $?
+    fi
     ;;
 
   *)

--- a/services/sysvinit/init.d/tedge-mapper-collectd
+++ b/services/sysvinit/init.d/tedge-mapper-collectd
@@ -131,7 +131,11 @@ case "$1" in
     ;;
 
   status)
-    status_of_proc -p "${PIDFILE}" "${DAEMON}" "tedge-mapper-collectd" && exit 0 || exit $?
+    if command -V status_of_proc >/dev/null 2>&1; then
+        status_of_proc -p "${PIDFILE}" "${DAEMON}" "tedge-mapper-collectd" && exit 0 || exit $?
+    else
+        status "${DAEMON}" && exit 0 || exit $?
+    fi
     ;;
 
   *)

--- a/services/sysvinit/service-start-stop-daemon.template
+++ b/services/sysvinit/service-start-stop-daemon.template
@@ -131,7 +131,11 @@ case "$1" in
     ;;
 
   status)
-    status_of_proc -p "${PIDFILE}" "${DAEMON}" "$NAME" && exit 0 || exit $?
+    if command -V status_of_proc >/dev/null 2>&1; then
+        status_of_proc -p "${PIDFILE}" "${DAEMON}" "$NAME" && exit 0 || exit $?
+    else
+        status "${DAEMON}" && exit 0 || exit $?
+    fi
     ;;
 
   *)


### PR DESCRIPTION
Improve compatibility between different linux distrubtions by supporting both status checks depending on what shell functions are available