### PR TITLE
feat(s6-overlay): use s6-format-filter for log formatting to avoid gnu sed dependency

### DIFF
--- a/images/s6-overlay/alpine-s6-overlay.dockerfile
+++ b/images/s6-overlay/alpine-s6-overlay.dockerfile
@@ -9,9 +9,7 @@ RUN apk update \
         ca-certificates \
         mosquitto \
         sudo \
-        curl \
-        # GNU sed (used in service definitions)
-        sed
+        curl
 
 # Install s6-overlay
 # Based on https://github.com/just-containers/s6-overlay#which-architecture-to-use-depending-on-your-targetarch

--- a/services/s6-overlay/s6-rc.d/c8y-firmware-plugin-log/run
+++ b/services/s6-overlay/s6-rc.d/c8y-firmware-plugin-log/run
@@ -1,2 +1,2 @@
-#!/bin/sh
-sed 's/^/\x1b[34mc8y-firmware-plugin |\x1b[0m /' --unbuffered
+#!/command/execlineb -P
+s6-format-filter "\033[34m%1 |\033[0m %s" c8y-firmware-plugin

--- a/services/s6-overlay/s6-rc.d/mosquitto-log/run
+++ b/services/s6-overlay/s6-rc.d/mosquitto-log/run
@@ -1,2 +1,2 @@
-#!/bin/sh
-sed 's/^/\x1b[34mmosquitto |\x1b[0m /' --unbuffered
+#!/command/execlineb -P
+s6-format-filter "\033[34m%1 |\033[0m %s" mosquitto

--- a/services/s6-overlay/s6-rc.d/tedge-agent-log/run
+++ b/services/s6-overlay/s6-rc.d/tedge-agent-log/run
@@ -1,2 +1,2 @@
-#!/bin/sh
-sed 's/^/\x1b[34mtedge-agent |\x1b[0m /' --unbuffered
+#!/command/execlineb -P
+s6-format-filter "\033[34m%1 |\033[0m %s" tedge-agent

--- a/services/s6-overlay/s6-rc.d/tedge-mapper-aws-log/run
+++ b/services/s6-overlay/s6-rc.d/tedge-mapper-aws-log/run
@@ -1,2 +1,2 @@
-#!/bin/sh
-sed 's/^/\x1b[34mtedge-mapper-aws |\x1b[0m /' --unbuffered
+#!/command/execlineb -P
+s6-format-filter "\033[34m%1 |\033[0m %s" tedge-mapper-aws

--- a/services/s6-overlay/s6-rc.d/tedge-mapper-az-log/run
+++ b/services/s6-overlay/s6-rc.d/tedge-mapper-az-log/run
@@ -1,2 +1,2 @@
-#!/bin/sh
-sed 's/^/\x1b[34mtedge-mapper-az |\x1b[0m /' --unbuffered
+#!/command/execlineb -P
+s6-format-filter "\033[34m%1 |\033[0m %s" tedge-mapper-az

--- a/services/s6-overlay/s6-rc.d/tedge-mapper-c8y-log/run
+++ b/services/s6-overlay/s6-rc.d/tedge-mapper-c8y-log/run
@@ -1,2 +1,2 @@
-#!/bin/sh
-sed 's/^/\x1b[34mtedge-mapper-c8y |\x1b[0m /' --unbuffered
+#!/command/execlineb -P
+s6-format-filter "\033[34m%1 |\033[0m %s" tedge-mapper-c8y

--- a/services/s6-overlay/s6-rc.d/tedge-mapper-collectd-log/run
+++ b/services/s6-overlay/s6-rc.d/tedge-mapper-collectd-log/run
@@ -1,2 +1,2 @@
-#!/bin/sh
-sed 's/^/\x1b[34mtedge-mapper-collectd |\x1b[0m /' --unbuffered
+#!/command/execlineb -P
+s6-format-filter "\033[34m%1 |\033[0m %s" tedge-mapper-collectd

--- a/services/s6-overlay/templates/service-log/run
+++ b/services/s6-overlay/templates/service-log/run
@@ -1,2 +1,2 @@
-#!/bin/sh
-sed 's/^/\x1b[34m$LOG_NAME |\x1b[0m /' --unbuffered
+#!/command/execlineb -P
+s6-format-filter "\033[34m%1 |\033[0m %s" $LOG_NAME


### PR DESCRIPTION
Remove the dependency to gnu sed by using `s6-format-filter` to add a service prefix to the log output