### PR TITLE
ci: update github actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: extractions/setup-just@v1
+      - uses: extractions/setup-just@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: '>=1.20.0'
       - run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,8 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '>=1.20.0'
+          go-version: 'stable'
+          cache: false
       - run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
         name: Install dependencies
 


### PR DESCRIPTION
Address deprecation warnings due to out of date gh actions.