### PR TITLE
fix(sysvinit): improve pidfile location fallback

### DIFF
--- a/services/sysvinit-yocto/service-background.template
+++ b/services/sysvinit-yocto/service-background.template
@@ -16,6 +16,11 @@ DAEMON_ARGS="$COMMAND_ARGS"
 
 name="$NAME"
 PIDFILE=/run/lock/$name.lock
+if [ -d /run/lock ]; then
+    PIDFILE=/run/lock/$name.lock
+else
+    PIDFILE=/var/run/$name.lock
+fi
 stdout_log="/var/log/$name.log"
 stderr_log="/var/log/$name.err"
 

--- a/services/sysvinit/service-start-stop-daemon.template
+++ b/services/sysvinit/service-start-stop-daemon.template
@@ -37,6 +37,11 @@ export TEDGE_RUN_LOCK_FILES="false"
 
 DAEMON=$COMMAND
 PIDFILE=/run/lock/$NAME.lock
+if [ -d /run/lock ]; then
+    PIDFILE=/run/lock/$NAME.lock
+else
+    PIDFILE=/var/run/$NAME.lock
+fi
 
 STOP_RETRY_SCHEDULE='TERM/30/KILL/1'
 


### PR DESCRIPTION
Check if the `/run/lock` folder exists before using it. Fallback to the `/var/run` folder as this seems to be used by yocto installations.