### PR TITLE
feat(systemd): add c8y-remote-access-plugin socket activation

### DIFF
--- a/services/systemd/system/c8y-remote-access-plugin.socket
+++ b/services/systemd/system/c8y-remote-access-plugin.socket
@@ -1,0 +1,13 @@
+[Unit]
+Description=c8y-remote-access-plugin socket
+PartOf=c8y-remote-access-plugin.service
+
+[Socket]
+ListenStream=/run/c8y-remote-access-plugin.sock
+SocketMode=0660
+SocketUser=tedge
+SocketGroup=tedge
+Accept=yes
+
+[Install]
+WantedBy=sockets.target

--- a/services/systemd/system/c8y-remote-access-plugin@.service
+++ b/services/systemd/system/c8y-remote-access-plugin@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=c8y-remote-access-plugin Service
+After=network.target c8y-remote-access-plugin.socket
+Requires=c8y-remote-access-plugin.socket
+CollectMode=inactive-or-failed
+
+[Service]
+ExecStart=/usr/bin/c8y-remote-access-plugin --child -
+StandardInput=socket
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Since thin-edge.io 1.2.0, c8y-remote-access-plugin supports systemd socket activation which enables the spawned remote access session to be fully independent of the tedge-mapper-c8y.

The systemd socket and service template have been added directly (outside of the script activation due to difficulties adapting the generator as it is written in bash and is not so easy to extend).