### PR TITLE
fix(s6-overlay): restart service bug when service is not already running

### DIFF
--- a/services/tedgectl
+++ b/services/tedgectl
@@ -154,7 +154,17 @@ manage_s6_overlay() {
         is_available) /command/s6-rc list ;;
         start) /command/s6-rc start "$name" ;;
         stop) /command/s6-rc stop "$name" ;;
-        restart) /command/s6-svc -r "/run/service/$name" ;;
+        restart)
+            # Note: if a service is not already running then it should be simply started as
+            # "s6-svc -r" as no affect if the service is not already running
+            if [ -f "/run/service/$name/down" ]; then
+                # Service is not already running, so just start it
+                /command/s6-rc start "$name"
+            else
+                # Restart an already running service by sending it a signal (via s6-svc)
+                /command/s6-svc -r "/run/service/$name"
+            fi
+            ;;
         enable) /command/s6-rc start "$name" ;;
         disable) /command/s6-rc stop "$name" ;;
         is_active|status)


### PR DESCRIPTION
In s6-overlay, if a service is not already running then it should be simply started as `s6-svc -r` as no affect if the service is not already running.

Previously the following sequence would lead to the service not being started when using the s6-overlay  init manager

1. `tedgectl stop mosquitto`
2. `tedgectl restart mosquitto`

This sequence would typically happen whilst running `tedge reconnect c8y` or `tedge connect c8y` as the tedge cli will restart mosquitto (not just `start`)