### PR TITLE
feat: add tedgectl to sudoers.d rule if sudo exists at install time

### DIFF
--- a/packages/_scripts/postremove.sh
+++ b/packages/_scripts/postremove.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+rm -f /etc/sudoers.d/100-tedge-tedgectl

--- a/packages/_scripts/preinstall.sh
+++ b/packages/_scripts/preinstall.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# Only add if /etc/sudoers.d exists
+if [ -d /etc/sudoers.d ]; then
+    echo "Adding tedgectl to /etc/sudoers.d/tedgectl" >&2
+    echo "tedge    ALL = (ALL) NOPASSWD: /usr/bin/tedgectl" > /etc/sudoers.d/100-tedge-tedgectl
+fi

--- a/packages/openrc/nfpm.yaml
+++ b/packages/openrc/nfpm.yaml
@@ -52,5 +52,7 @@ contents:
       mode: 0644
 
 scripts:
+  preinstall: ./packages/_scripts/preinstall.sh
   postinstall: ./packages/_scripts/postinstall.sh
   preremove: ./packages/_scripts/preremove.sh
+  postremove: ./packages/_scripts/postremove.sh

--- a/packages/runit/nfpm.yaml
+++ b/packages/runit/nfpm.yaml
@@ -45,5 +45,7 @@ contents:
       mode: 0644
 
 scripts:
+  preinstall: ./packages/_scripts/preinstall.sh
   postinstall: ./packages/_scripts/postinstall.sh
   preremove: ./packages/_scripts/preremove.sh
+  postremove: ./packages/_scripts/postremove.sh

--- a/packages/s6-overlay/nfpm.yaml
+++ b/packages/s6-overlay/nfpm.yaml
@@ -45,5 +45,7 @@ contents:
       mode: 0644
 
 scripts:
+  preinstall: ./packages/_scripts/preinstall.sh
   postinstall: ./packages/_scripts/postinstall.sh
   preremove: ./packages/_scripts/preremove.sh
+  postremove: ./packages/_scripts/postremove.sh

--- a/packages/supervisord/nfpm.yaml
+++ b/packages/supervisord/nfpm.yaml
@@ -47,5 +47,7 @@ contents:
       mode: 0644
 
 scripts:
+  preinstall: ./packages/_scripts/preinstall.sh
   postinstall: ./packages/_scripts/postinstall.sh
   preremove: ./packages/_scripts/preremove.sh
+  postremove: ./packages/_scripts/postremove.sh

--- a/packages/systemd/nfpm.yaml
+++ b/packages/systemd/nfpm.yaml
@@ -48,5 +48,7 @@ contents:
   #     mode: 0644
 
 scripts:
+  preinstall: ./packages/_scripts/preinstall.sh
   postinstall: ./packages/_scripts/postinstall.sh
   preremove: ./packages/_scripts/preremove.sh
+  postremove: ./packages/_scripts/postremove.sh

--- a/packages/sysvinit-yocto/nfpm.yaml
+++ b/packages/sysvinit-yocto/nfpm.yaml
@@ -47,5 +47,7 @@ contents:
       mode: 0644
 
 scripts:
+  preinstall: ./packages/_scripts/preinstall.sh
   postinstall: ./packages/_scripts/postinstall.sh
   preremove: ./packages/_scripts/preremove.sh
+  postremove: ./packages/_scripts/postremove.sh

--- a/packages/sysvinit/nfpm.yaml
+++ b/packages/sysvinit/nfpm.yaml
@@ -47,5 +47,7 @@ contents:
       mode: 0644
 
 scripts:
+  preinstall: ./packages/_scripts/preinstall.sh
   postinstall: ./packages/_scripts/postinstall.sh
   preremove: ./packages/_scripts/preremove.sh
+  postremove: ./packages/_scripts/postremove.sh


### PR DESCRIPTION
Given that `tedgectl` is also used to restart the device when other init systems other than systemd, the `tedge` user needs to be able to call the command via sudo (e.g. `/etc/sudoers.d/100-tedge-tedgectl`).