### PR TITLE
fix(apk): run pre and post install hooks during upgrades

### DIFF
--- a/packages/_scripts/preinstall.sh
+++ b/packages/_scripts/preinstall.sh
@@ -3,6 +3,6 @@ set -e
 
 # Only add if /etc/sudoers.d exists
 if [ -d /etc/sudoers.d ]; then
-    echo "Adding tedgectl to /etc/sudoers.d/tedgectl" >&2
+    echo "Adding tedgectl to 100-tedge-tedgectl" >&2
     echo "tedge    ALL = (ALL) NOPASSWD: /usr/bin/tedgectl" > /etc/sudoers.d/100-tedge-tedgectl
 fi

--- a/packages/openrc/nfpm.yaml
+++ b/packages/openrc/nfpm.yaml
@@ -17,6 +17,10 @@ depends:
 apk:
   # Use noarch instead of "all"
   arch: noarch
+  scripts:
+    # Alpine Linux uses different hooks for upgrades
+    preupgrade: ./packages/_scripts/preinstall.sh
+    postupgrade: ./packages/_scripts/postinstall.sh
 contents:
   - src: ./services/openrc/init.d/*
     dst: /etc/init.d/

--- a/packages/runit/nfpm.yaml
+++ b/packages/runit/nfpm.yaml
@@ -15,6 +15,10 @@ license: Apache License 2.0
 apk:
   # Use noarch instead of "all"
   arch: noarch
+  scripts:
+    # Alpine Linux uses different hooks for upgrades
+    preupgrade: ./packages/_scripts/preinstall.sh
+    postupgrade: ./packages/_scripts/postinstall.sh
 contents:
   - src: ./services/runit/runsvdir
     dst: /etc/runit

--- a/packages/s6-overlay/nfpm.yaml
+++ b/packages/s6-overlay/nfpm.yaml
@@ -15,6 +15,10 @@ license: Apache License 2.0
 apk:
   # Use noarch instead of "all"
   arch: noarch
+  scripts:
+    # Alpine Linux uses different hooks for upgrades
+    preupgrade: ./packages/_scripts/preinstall.sh
+    postupgrade: ./packages/_scripts/postinstall.sh
 contents:
   - src: ./services/s6-overlay/s6-rc.d
     dst: /etc/s6-overlay/s6-rc.d

--- a/packages/supervisord/nfpm.yaml
+++ b/packages/supervisord/nfpm.yaml
@@ -15,6 +15,10 @@ license: Apache License 2.0
 apk:
   # Use noarch instead of "all"
   arch: noarch
+  scripts:
+    # Alpine Linux uses different hooks for upgrades
+    preupgrade: ./packages/_scripts/preinstall.sh
+    postupgrade: ./packages/_scripts/postinstall.sh
 contents:
   - src: ./services/supervisord/conf.d/*
     dst: /etc/supervisor/conf.d/

--- a/packages/systemd/nfpm.yaml
+++ b/packages/systemd/nfpm.yaml
@@ -15,6 +15,10 @@ license: Apache License 2.0
 apk:
   # Use noarch instead of "all"
   arch: noarch
+  scripts:
+    # Alpine Linux uses different hooks for upgrades
+    preupgrade: ./packages/_scripts/preinstall.sh
+    postupgrade: ./packages/_scripts/postinstall.sh
 contents:
   - src: ./services/systemd/system/*
     dst: /lib/systemd/system/

--- a/packages/sysvinit-yocto/nfpm.yaml
+++ b/packages/sysvinit-yocto/nfpm.yaml
@@ -15,6 +15,10 @@ license: Apache License 2.0
 apk:
   # Use noarch instead of "all"
   arch: noarch
+  scripts:
+    # Alpine Linux uses different hooks for upgrades
+    preupgrade: ./packages/_scripts/preinstall.sh
+    postupgrade: ./packages/_scripts/postinstall.sh
 contents:
   - src: ./services/sysvinit-yocto/init.d/*
     dst: /etc/init.d/

--- a/packages/sysvinit/nfpm.yaml
+++ b/packages/sysvinit/nfpm.yaml
@@ -15,6 +15,10 @@ license: Apache License 2.0
 apk:
   # Use noarch instead of "all"
   arch: noarch
+  scripts:
+    # Alpine Linux uses different hooks for upgrades
+    preupgrade: ./packages/_scripts/preinstall.sh
+    postupgrade: ./packages/_scripts/postinstall.sh
 contents:
   - src: ./services/sysvinit/init.d/*
     dst: /etc/init.d/


### PR DESCRIPTION
When upgrading apk packages, the `postinst` and `preinst` hooks are not run, instead only the pre-upgrade and post-upgrade are called (but the same scripts can be reused).